### PR TITLE
Revert "Added lookup for base call sign in case compound call cannot be found"

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4703,24 +4703,6 @@ function lotw_last_qsl_date($user_id) {
       }
     }
 
-    function get_plaincall($callsign) {
-		$split_callsign=explode('/',$callsign);
-		if (count($split_callsign)==1) {				// case F0ABC --> return cel 0 //
-			$lookupcall = $split_callsign[0];
-		} else if (count($split_callsign)==3) {			// case EA/F0ABC/P --> return cel 1 //
-			$lookupcall = $split_callsign[1];
-		} else {										// case F0ABC/P --> return cel 0 OR  case EA/FOABC --> retunr 1  (normaly not exist) //
-			if (in_array(strtoupper($split_callsign[1]), array('P','M','MM','QRP','0','1','2','3','4','5','6','7','8','9'))) {
-				$lookupcall = $split_callsign[0];
-			} else if (strlen($split_callsign[1])>3) {	// Last Element longer than 3 chars? Take that as call
-				$lookupcall = $split_callsign[1];
-			} else {									// Last Element up to 3 Chars? Take first element as Call
-				$lookupcall = $split_callsign[0];
-			}
-		}
-		return $lookupcall;
-	}
-
 	public function loadCallBook($callsign, $use_fullname=false)
     {
         $callbook = null;
@@ -4742,10 +4724,6 @@ function lotw_last_qsl_date($user_id) {
                     $qrz_session_key = $this->qrz->session($this->config->item('qrz_username'), $this->config->item('qrz_password'));
                     $this->session->set_userdata('qrz_session_key', $qrz_session_key);
                     $callbook = $this->qrz->search($callsign, $this->session->userdata('qrz_session_key'), $use_fullname);
-					// if we still got nothing, and it's a compound callsign, then try a search for the base call
-					if (($callbook['callsign'] ?? '') == '' && strpos($callsign,"/")!==false){
-						$callbook = $this->qrz->search($this->get_plaincall($callsign), $this->session->userdata('qrz_session_key'), $use_fullname);
-					}                    
                 }
             }
 


### PR DESCRIPTION
Reverts m0urs/wavelog#9

This issue has now been fixed in a more approved way in the official repository, so this quick fix is no longer needed.